### PR TITLE
Add AWS Bedrock support with Claude Sonnet 4 and Opus 4.1

### DIFF
--- a/.env.bedrock-test
+++ b/.env.bedrock-test
@@ -1,0 +1,3 @@
+AI_PROVIDER=bedrock
+AWS_REGION=us-east-1
+BEDROCK_MODEL=sonnet-4

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,50 @@
-# Copy this file to .env and add your actual API key
-ANTHROPIC_API_KEY=your-anthropic-api-key-here
+# Example environment configuration
+# Copy this file to .env and set your actual values
+
+# =============================================================================
+# AI Provider Configuration
+# =============================================================================
+# Set to "anthropic" for direct API access or "bedrock" for AWS Bedrock
+AI_PROVIDER=anthropic
+
+# =============================================================================
+# Anthropic API Configuration (when AI_PROVIDER=anthropic)
+# =============================================================================
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# =============================================================================
+# AWS Bedrock Configuration (when AI_PROVIDER=bedrock)
+# =============================================================================
+# AWS Region where your Bedrock models are available
+AWS_REGION=us-east-1
+
+# Option 1: Use AWS Profile (recommended)
+AWS_PROFILE=your-aws-profile-name
+
+# Option 2: Use explicit credentials (leave AWS_PROFILE empty if using this)
+# AWS_ACCESS_KEY_ID=your_aws_access_key_id
+# AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+
+# Bedrock model to use (sonnet-4, opus-4.1, or haiku-3.5)
+BEDROCK_MODEL=sonnet-4
+
+# =============================================================================
+# Example Configurations
+# =============================================================================
+
+# For AWS Bedrock with Profile:
+# AI_PROVIDER=bedrock
+# AWS_REGION=us-east-1
+# AWS_PROFILE=your-profile
+# BEDROCK_MODEL=sonnet-4
+
+# For AWS Bedrock with explicit credentials:
+# AI_PROVIDER=bedrock
+# AWS_REGION=us-east-1
+# AWS_ACCESS_KEY_ID=your_key
+# AWS_SECRET_ACCESS_KEY=your_secret
+# BEDROCK_MODEL=opus-4.1
+
+# For direct Anthropic API:
+# AI_PROVIDER=anthropic
+# ANTHROPIC_API_KEY=your_key

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,17 @@
 AI_PROVIDER=anthropic
 
 # =============================================================================
+# QUICK START OPTIONS
+# =============================================================================
+
+# Option 1: Direct Anthropic API (Default)
+# Just set ANTHROPIC_API_KEY and you're ready to go!
+
+# Option 2: AWS Bedrock (Recommended for AWS users)  
+# Just set AI_PROVIDER=bedrock and ensure AWS credentials are configured
+# The app will auto-detect your AWS profile and use sensible defaults
+
+# =============================================================================
 # Anthropic API Configuration (when AI_PROVIDER=anthropic)
 # =============================================================================
 ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,11 @@ __pycache__/
 venv/
 env/
 ENV/
+.venv/
 
 # ChromaDB
 backend/chroma_db/
+chroma_db/
 
 # Uploads
 uploads/
@@ -25,6 +27,22 @@ uploads/
 .idea/
 *.swp
 *.swo
+
+# Logs
+*.log
+server.log
+
+# Temporary files
+*.tmp
+*.temp
+.env.test
+.env.bedrock-test
+
+# Documentation artifacts
+query-flow*.png
+query-flow*.txt
+query-flow*.mmd
+pr-description.md
 
 # OS
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,20 @@ All models defined in `models.py`:
 7. **VectorStore** (`vector_store.py`): ChromaDB similarity search with filtering
 8. **Response Path**: Results → AI synthesis → Session storage → Frontend display
 
-![Query Flow Diagram](query-flow-diagram.png)
+### Query Flow Summary
+```
+User Input → FastAPI → RAGSystem → AIGenerator → Claude API
+    ↓
+Claude Decision: Search needed?
+    ↓                    ↓
+Course Search        General Knowledge
+    ↓                    ↓
+VectorStore → ChromaDB   Direct Response
+    ↓                    ↓
+Search Results ←────────⌘
+    ↓
+AI Synthesis → Session Storage → Frontend Response
+```
 
 The key architectural insight: **Intelligent tool usage** - Claude decides when to search course content vs. using general knowledge, demonstrating how AI assistants can make smart decisions about tool usage.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,18 @@ This is the companion codebase for the DeepLearning.AI course: **"Claude Code: A
 
 ### Running the Application
 - **Quick start**: `./run.sh` (starts server on port 8000)
-- **Manual start**: `cd backend && uv run uvicorn app:app --reload --port 8000`
+- **Manual start**: `uv run uvicorn backend.app:app --reload --port 8000` (from root)
+- **Legacy method**: `cd backend && uv run uvicorn app:app --reload --port 8000`
 - **Access points**: 
   - Web interface: http://localhost:8000
   - API docs: http://localhost:8000/docs
+
+### AI Provider Configuration
+- **Default**: Direct Anthropic API (`ANTHROPIC_API_KEY` required)
+- **AWS Bedrock**: Set `AI_PROVIDER=bedrock` in .env file
+  - Auto-detects AWS credentials from profile/environment
+  - Uses Claude Sonnet 4 by default with sensible regional settings
+  - Minimal configuration required - just set provider type
 
 ### Python Environment
 - Uses `uv` package manager (not pip/conda)
@@ -53,8 +61,11 @@ All models defined in `models.py`:
 
 ### Key Configuration
 - **Config class** (`config.py`): Centralizes all settings including API keys, chunk sizes, and model parameters
-- **Environment**: Uses `.env` file for sensitive data like `ANTHROPIC_API_KEY`
-- **Model**: Currently uses `claude-sonnet-4-20250514`
+- **Environment**: Uses `.env` file for sensitive data and provider configuration
+- **AI Providers**: 
+  - Direct Anthropic: Uses `claude-sonnet-4-20250514` 
+  - AWS Bedrock: Uses `us.anthropic.claude-sonnet-4-20250514-v1:0` (inference profile)
+- **Factory Pattern**: `create_ai_generator()` automatically selects provider based on config
 
 ### Document Processing Flow
 1. Documents from `/docs/` folder are processed on startup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,6 @@ The key architectural insight: **Intelligent tool usage** - Claude decides when 
 - Uses ChromaDB for persistence (stored in `./chroma_db/`)
 - Course content loaded from `/docs/` on application startup
 - All components follow dependency injection pattern through the config object
+
+## Commit Guidelines
+- Never include any Claude or bot specific verbiage in commit messages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Context
+
+This is the companion codebase for the DeepLearning.AI course: **"Claude Code: A Highly Agentic Coding Assistant"**
+- Course URL: https://www.deeplearning.ai/short-courses/claude-code-a-highly-agentic-coding-assistant/
+- This serves as a practical example of building RAG systems that integrate with AI coding assistants
+
+## Development Commands
+
+### Project Setup
+- **Install dependencies**: `uv sync`
+- **Create .env file**: Copy `.env.example` to `.env` and add `ANTHROPIC_API_KEY=your_key_here`
+- **Always use uv to run any python code**
+- **For any uv commands that sync, add, install or upgrade dependencies, prepend them with `UV_EXTRA_INDEX_URL= `**
+
+### Running the Application
+- **Quick start**: `./run.sh` (starts server on port 8000)
+- **Manual start**: `cd backend && uv run uvicorn app:app --reload --port 8000`
+- **Access points**: 
+  - Web interface: http://localhost:8000
+  - API docs: http://localhost:8000/docs
+
+### Python Environment
+- Uses `uv` package manager (not pip/conda)
+- Python 3.13+ required
+- No test framework currently configured
+
+## Architecture Overview
+
+This is a RAG (Retrieval-Augmented Generation) chatbot system with a modular backend architecture:
+
+### Core Components
+- **RAGSystem** (`rag_system.py`): Main orchestrator that coordinates all components
+- **VectorStore** (`vector_store.py`): ChromaDB-based vector storage for course content and metadata
+- **AIGenerator** (`ai_generator.py`): Anthropic Claude API integration with tool support
+- **DocumentProcessor** (`document_processor.py`): Processes course documents into structured chunks
+- **SessionManager** (`session_manager.py`): Manages conversation history and sessions
+- **ToolManager** (`search_tools.py`): Handles AI tool-based search functionality
+
+### Data Models
+All models defined in `models.py`:
+- **Course**: Contains course metadata, lessons, and instructor info
+- **Lesson**: Individual lessons with titles and links
+- **CourseChunk**: Text chunks for vector storage with course/lesson context
+
+### API Structure
+- **FastAPI** backend in `backend/app.py` with CORS enabled
+- **Frontend**: Static HTML/CSS/JS served from `/frontend/`
+- **Main endpoints**: `/api/query` (chat), `/api/courses` (stats)
+
+### Key Configuration
+- **Config class** (`config.py`): Centralizes all settings including API keys, chunk sizes, and model parameters
+- **Environment**: Uses `.env` file for sensitive data like `ANTHROPIC_API_KEY`
+- **Model**: Currently uses `claude-sonnet-4-20250514`
+
+### Document Processing Flow
+1. Documents from `/docs/` folder are processed on startup
+2. Content is chunked (800 chars, 100 overlap) and embedded
+3. Vector storage includes both course metadata and content chunks
+4. AI uses tool-based search to retrieve relevant content
+
+### Session Management
+- Conversation history maintained per session ID
+- Limited to 2 previous exchanges (configurable in `config.py`)
+- Sessions created automatically if not provided
+
+## Query Flow Architecture
+
+### User Query Processing Flow
+1. **Frontend** (`script.js`): User input → POST `/api/query` with session tracking
+2. **FastAPI** (`app.py`): Route handling → RAG system delegation  
+3. **RAGSystem** (`rag_system.py`): Orchestrates components, manages conversation history
+4. **AIGenerator** (`ai_generator.py`): Claude API integration with tool definitions
+5. **Tool Decision**: Claude automatically decides whether to search based on query type
+6. **CourseSearchTool** (`search_tools.py`): Semantic search execution if needed
+7. **VectorStore** (`vector_store.py`): ChromaDB similarity search with filtering
+8. **Response Path**: Results → AI synthesis → Session storage → Frontend display
+
+![Query Flow Diagram](query-flow-diagram.png)
+
+The key architectural insight: **Intelligent tool usage** - Claude decides when to search course content vs. using general knowledge, demonstrating how AI assistants can make smart decisions about tool usage.
+
+## Important Notes
+- No existing test suite - add tests when implementing new features  
+- Uses ChromaDB for persistence (stored in `./chroma_db/`)
+- Course content loaded from `/docs/` on application startup
+- All components follow dependency injection pattern through the config object

--- a/README.md
+++ b/README.md
@@ -4,14 +4,22 @@ A Retrieval-Augmented Generation (RAG) system designed to answer questions about
 
 ## Overview
 
-This application is a full-stack web application that enables users to query course materials and receive intelligent, context-aware responses. It uses ChromaDB for vector storage, Anthropic's Claude for AI generation, and provides a web interface for interaction.
+This application is a full-stack web application that enables users to query course materials and receive intelligent, context-aware responses. It uses ChromaDB for vector storage, Claude AI for response generation, and provides a web interface for interaction.
 
+## AI Provider Options
+
+This application supports two ways to access Claude AI:
+
+- **Direct Anthropic API** - Use your Anthropic API key directly
+- **AWS Bedrock** - Use Claude through AWS Bedrock (recommended for AWS users)
 
 ## Prerequisites
 
 - Python 3.13 or higher
 - uv (Python package manager)
-- An Anthropic API key (for Claude AI)
+- **Either:**
+  - An Anthropic API key, **OR**
+  - AWS credentials configured (for Bedrock access)
 - **For Windows**: Use Git Bash to run the application commands - [Download Git for Windows](https://git-scm.com/downloads/win)
 
 ## Installation
@@ -28,10 +36,31 @@ This application is a full-stack web application that enables users to query cou
 
 3. **Set up environment variables**
    
-   Create a `.env` file in the root directory:
+   Create a `.env` file in the root directory with one of the following configurations:
+
+   **Option A: Direct Anthropic API (Default)**
    ```bash
    ANTHROPIC_API_KEY=your_anthropic_api_key_here
    ```
+
+   **Option B: AWS Bedrock (Recommended)**
+   ```bash
+   AI_PROVIDER=bedrock
+   # AWS credentials will be auto-detected from your AWS profile/environment
+   ```
+
+   **Advanced Bedrock Configuration (Optional)**
+   ```bash
+   AI_PROVIDER=bedrock
+   AWS_REGION=us-east-1           # Default: us-east-1
+   AWS_PROFILE=your-profile-name  # Optional: use specific AWS profile
+   BEDROCK_MODEL=sonnet-4         # Default: sonnet-4 (Claude Sonnet 4)
+   ```
+
+   **Available Bedrock Models:**
+   - `sonnet-4` - Claude Sonnet 4 (recommended)
+   - `opus-4.1` - Claude Opus 4.1 (most capable)
+   - `haiku-3.5` - Claude Haiku 3.5 (fastest)
 
 ## Running the Application
 
@@ -45,6 +74,12 @@ chmod +x run.sh
 
 ### Manual Start
 
+**From project root (recommended):**
+```bash
+uv run uvicorn backend.app:app --reload --port 8000
+```
+
+**Legacy method (from backend directory):**
 ```bash
 cd backend
 uv run uvicorn app:app --reload --port 8000
@@ -53,4 +88,23 @@ uv run uvicorn app:app --reload --port 8000
 The application will be available at:
 - Web Interface: `http://localhost:8000`
 - API Documentation: `http://localhost:8000/docs`
+
+## AWS Bedrock Setup
+
+If you're using AWS Bedrock, ensure your AWS credentials are configured:
+
+```bash
+# Option 1: Use AWS Profile (recommended)
+aws configure --profile your-profile-name
+
+# Option 2: Use environment variables
+export AWS_ACCESS_KEY_ID=your_access_key
+export AWS_SECRET_ACCESS_KEY=your_secret_key
+export AWS_REGION=us-east-1
+
+# Option 3: Use default AWS credentials
+aws configure
+```
+
+The application will automatically detect your AWS credentials and connect to Bedrock.
 

--- a/backend/ai_generator.py
+++ b/backend/ai_generator.py
@@ -1,8 +1,11 @@
 import anthropic
+import boto3
+import json
+from abc import ABC, abstractmethod
 from typing import List, Optional, Dict, Any
 
-class AIGenerator:
-    """Handles interactions with Anthropic's Claude API for generating responses"""
+class BaseAIGenerator(ABC):
+    """Abstract base class for AI generators"""
     
     # Static system prompt to avoid rebuilding on each call
     SYSTEM_PROMPT = """ You are an AI assistant specialized in course materials and educational content with access to a comprehensive search tool for course information.
@@ -28,6 +31,18 @@ All responses must be:
 4. **Example-supported** - Include relevant examples when they aid understanding
 Provide only the direct answer to what was asked.
 """
+
+    @abstractmethod
+    def generate_response(self, query: str,
+                         conversation_history: Optional[str] = None,
+                         tools: Optional[List] = None,
+                         tool_manager=None) -> str:
+        """Generate AI response with optional tool usage and conversation context"""
+        pass
+
+
+class AnthropicAIGenerator(BaseAIGenerator):
+    """Handles interactions with Anthropic's Claude API for generating responses"""
     
     def __init__(self, api_key: str, model: str):
         self.client = anthropic.Anthropic(api_key=api_key)
@@ -133,3 +148,183 @@ Provide only the direct answer to what was asked.
         # Get final response
         final_response = self.client.messages.create(**final_params)
         return final_response.content[0].text
+
+
+class BedrockAIGenerator(BaseAIGenerator):
+    """Handles interactions with AWS Bedrock Claude API for generating responses"""
+    
+    def __init__(self, region: str, model_id: str, aws_profile: str = "", 
+                 aws_access_key_id: str = "", aws_secret_access_key: str = ""):
+        self.model_id = model_id
+        self.region = region
+        
+        # Initialize boto3 session with flexible authentication
+        if aws_profile:
+            # Use AWS profile
+            session = boto3.Session(profile_name=aws_profile)
+        elif aws_access_key_id and aws_secret_access_key:
+            # Use explicit credentials
+            session = boto3.Session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                region_name=region
+            )
+        else:
+            # Use default credential chain
+            session = boto3.Session(region_name=region)
+        
+        self.bedrock = session.client('bedrock-runtime')
+        
+        # Base parameters for Bedrock
+        self.base_params = {
+            "temperature": 0,
+            "max_tokens": 800
+        }
+    
+    def generate_response(self, query: str,
+                         conversation_history: Optional[str] = None,
+                         tools: Optional[List] = None,
+                         tool_manager=None) -> str:
+        """
+        Generate AI response using AWS Bedrock with optional tool usage.
+        
+        Args:
+            query: The user's question or request
+            conversation_history: Previous messages for context
+            tools: Available tools the AI can use
+            tool_manager: Manager to execute tools
+            
+        Returns:
+            Generated response as string
+        """
+        
+        # Build system content
+        system_content = (
+            f"{self.SYSTEM_PROMPT}\n\nPrevious conversation:\n{conversation_history}"
+            if conversation_history 
+            else self.SYSTEM_PROMPT
+        )
+        
+        # Prepare messages for Bedrock format
+        messages = [{"role": "user", "content": query}]
+        
+        # Prepare the request body
+        request_body = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "system": system_content,
+            "messages": messages,
+            **self.base_params
+        }
+        
+        # Add tools if available
+        if tools:
+            request_body["tools"] = tools
+            request_body["tool_choice"] = {"type": "auto"}
+        
+        # Make the API call
+        response = self.bedrock.invoke_model(
+            modelId=self.model_id,
+            body=json.dumps(request_body),
+            contentType='application/json'
+        )
+        
+        # Parse response
+        response_body = json.loads(response['body'].read())
+        
+        # Handle tool execution if needed
+        if response_body.get("stop_reason") == "tool_use" and tool_manager:
+            return self._handle_bedrock_tool_execution(response_body, request_body, tool_manager)
+        
+        # Return direct response
+        return response_body["content"][0]["text"]
+    
+    def _handle_bedrock_tool_execution(self, initial_response: Dict, base_request: Dict, tool_manager):
+        """
+        Handle execution of tool calls for Bedrock API.
+        
+        Args:
+            initial_response: The response containing tool use requests
+            base_request: Base request parameters
+            tool_manager: Manager to execute tools
+            
+        Returns:
+            Final response text after tool execution
+        """
+        # Start with existing messages
+        messages = base_request["messages"].copy()
+        
+        # Add AI's tool use response
+        messages.append({
+            "role": "assistant", 
+            "content": initial_response["content"]
+        })
+        
+        # Execute all tool calls and collect results
+        tool_results = []
+        for content_block in initial_response["content"]:
+            if content_block.get("type") == "tool_use":
+                tool_result = tool_manager.execute_tool(
+                    content_block["name"], 
+                    **content_block["input"]
+                )
+                
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": content_block["id"],
+                    "content": tool_result
+                })
+        
+        # Add tool results as single message
+        if tool_results:
+            messages.append({"role": "user", "content": tool_results})
+        
+        # Prepare final request without tools
+        final_request = {
+            **base_request,
+            "messages": messages
+        }
+        # Remove tools from final request
+        final_request.pop("tools", None)
+        final_request.pop("tool_choice", None)
+        
+        # Make final API call
+        final_response = self.bedrock.invoke_model(
+            modelId=self.model_id,
+            body=json.dumps(final_request),
+            contentType='application/json'
+        )
+        
+        # Parse and return response
+        final_response_body = json.loads(final_response['body'].read())
+        return final_response_body["content"][0]["text"]
+
+
+# Factory function for creating AI generators
+def create_ai_generator(config) -> BaseAIGenerator:
+    """
+    Factory function to create the appropriate AI generator based on configuration.
+    
+    Args:
+        config: Configuration object containing provider settings
+        
+    Returns:
+        BaseAIGenerator instance
+    """
+    if config.AI_PROVIDER.lower() == "bedrock":
+        return BedrockAIGenerator(
+            region=config.AWS_REGION,
+            model_id=config.get_bedrock_model_id(),
+            aws_profile=config.AWS_PROFILE,
+            aws_access_key_id=config.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=config.AWS_SECRET_ACCESS_KEY
+        )
+    else:
+        # Default to Anthropic
+        return AnthropicAIGenerator(
+            api_key=config.ANTHROPIC_API_KEY,
+            model=config.ANTHROPIC_MODEL
+        )
+
+
+# Maintain backward compatibility
+AIGenerator = AnthropicAIGenerator

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,8 +9,8 @@ from pydantic import BaseModel
 from typing import List, Optional
 import os
 
-from config import config
-from rag_system import RAGSystem
+from backend.config import config
+from backend.rag_system import RAGSystem
 
 # Initialize FastAPI app
 app = FastAPI(title="Course Materials RAG System", root_path="")
@@ -88,7 +88,7 @@ async def get_course_stats():
 @app.on_event("startup")
 async def startup_event():
     """Load initial documents on startup"""
-    docs_path = "../docs"
+    docs_path = "docs"
     if os.path.exists(docs_path):
         print("Loading initial documents...")
         try:
@@ -116,4 +116,4 @@ class DevStaticFiles(StaticFiles):
     
     
 # Serve static files for the frontend
-app.mount("/", StaticFiles(directory="../frontend", html=True), name="static")
+app.mount("/", StaticFiles(directory="frontend", html=True), name="static")

--- a/backend/config.py
+++ b/backend/config.py
@@ -21,11 +21,14 @@ class Config:
     AWS_ACCESS_KEY_ID: str = os.getenv("AWS_ACCESS_KEY_ID", "")  # For explicit creds
     AWS_SECRET_ACCESS_KEY: str = os.getenv("AWS_SECRET_ACCESS_KEY", "")
     
-    # Bedrock model mapping
+    # Bedrock model mapping (using inference profiles for latest models)
     BEDROCK_MODELS = {
-        "sonnet-4": "anthropic.claude-sonnet-4-20250514-v1:0",
-        "opus-4.1": "anthropic.claude-opus-4-1-20250805-v1:0", 
-        "haiku-3.5": "anthropic.claude-3-5-haiku-20241022-v1:0"
+        "sonnet-4": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        "opus-4.1": "us.anthropic.claude-opus-4-1-20250805-v1:0", 
+        "haiku-3.5": "anthropic.claude-3-5-haiku-20241022-v1:0",  # Direct model if available
+        # Fallback to working models
+        "claude-v2": "anthropic.claude-v2",
+        "claude-instant": "anthropic.claude-instant-v1"
     }
     BEDROCK_MODEL: str = os.getenv("BEDROCK_MODEL", "sonnet-4")
     

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,9 +8,26 @@ load_dotenv()
 @dataclass
 class Config:
     """Configuration settings for the RAG system"""
+    # AI Provider settings
+    AI_PROVIDER: str = os.getenv("AI_PROVIDER", "anthropic")  # "anthropic" or "bedrock"
+    
     # Anthropic API settings
     ANTHROPIC_API_KEY: str = os.getenv("ANTHROPIC_API_KEY", "")
     ANTHROPIC_MODEL: str = "claude-sonnet-4-20250514"
+    
+    # AWS Bedrock settings
+    AWS_REGION: str = os.getenv("AWS_REGION", "us-east-1")
+    AWS_PROFILE: str = os.getenv("AWS_PROFILE", "")  # For profile-based auth
+    AWS_ACCESS_KEY_ID: str = os.getenv("AWS_ACCESS_KEY_ID", "")  # For explicit creds
+    AWS_SECRET_ACCESS_KEY: str = os.getenv("AWS_SECRET_ACCESS_KEY", "")
+    
+    # Bedrock model mapping
+    BEDROCK_MODELS = {
+        "sonnet-4": "anthropic.claude-sonnet-4-20250514-v1:0",
+        "opus-4.1": "anthropic.claude-opus-4-1-20250805-v1:0", 
+        "haiku-3.5": "anthropic.claude-3-5-haiku-20241022-v1:0"
+    }
+    BEDROCK_MODEL: str = os.getenv("BEDROCK_MODEL", "sonnet-4")
     
     # Embedding model settings
     EMBEDDING_MODEL: str = "all-MiniLM-L6-v2"
@@ -23,6 +40,10 @@ class Config:
     
     # Database paths
     CHROMA_PATH: str = "./chroma_db"  # ChromaDB storage location
+    
+    def get_bedrock_model_id(self) -> str:
+        """Get the full Bedrock model ID"""
+        return self.BEDROCK_MODELS.get(self.BEDROCK_MODEL, self.BEDROCK_MODELS["sonnet-4"])
 
 config = Config()
 

--- a/backend/document_processor.py
+++ b/backend/document_processor.py
@@ -1,7 +1,7 @@
 import os
 import re
 from typing import List, Tuple
-from models import Course, Lesson, CourseChunk
+from backend.models import Course, Lesson, CourseChunk
 
 class DocumentProcessor:
     """Processes course documents and extracts structured information"""

--- a/backend/rag_system.py
+++ b/backend/rag_system.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Optional, Dict
 import os
 from document_processor import DocumentProcessor
 from vector_store import VectorStore
-from ai_generator import AIGenerator
+from ai_generator import create_ai_generator
 from session_manager import SessionManager
 from search_tools import ToolManager, CourseSearchTool
 from models import Course, Lesson, CourseChunk
@@ -16,7 +16,7 @@ class RAGSystem:
         # Initialize core components
         self.document_processor = DocumentProcessor(config.CHUNK_SIZE, config.CHUNK_OVERLAP)
         self.vector_store = VectorStore(config.CHROMA_PATH, config.EMBEDDING_MODEL, config.MAX_RESULTS)
-        self.ai_generator = AIGenerator(config.ANTHROPIC_API_KEY, config.ANTHROPIC_MODEL)
+        self.ai_generator = create_ai_generator(config)
         self.session_manager = SessionManager(config.MAX_HISTORY)
         
         # Initialize search tools

--- a/backend/rag_system.py
+++ b/backend/rag_system.py
@@ -1,11 +1,11 @@
 from typing import List, Tuple, Optional, Dict
 import os
-from document_processor import DocumentProcessor
-from vector_store import VectorStore
-from ai_generator import create_ai_generator
-from session_manager import SessionManager
-from search_tools import ToolManager, CourseSearchTool
-from models import Course, Lesson, CourseChunk
+from backend.document_processor import DocumentProcessor
+from backend.vector_store import VectorStore
+from backend.ai_generator import create_ai_generator
+from backend.session_manager import SessionManager
+from backend.search_tools import ToolManager, CourseSearchTool
+from backend.models import Course, Lesson, CourseChunk
 
 class RAGSystem:
     """Main orchestrator for the Retrieval-Augmented Generation system"""

--- a/backend/search_tools.py
+++ b/backend/search_tools.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any, Optional, Protocol
 from abc import ABC, abstractmethod
-from vector_store import VectorStore, SearchResults
+from backend.vector_store import VectorStore, SearchResults
 
 
 class Tool(ABC):

--- a/backend/vector_store.py
+++ b/backend/vector_store.py
@@ -2,7 +2,7 @@ import chromadb
 from chromadb.config import Settings
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
-from models import Course, CourseChunk
+from backend.models import Course, CourseChunk
 from sentence_transformers import SentenceTransformer
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "uvicorn==0.35.0",
     "python-multipart==0.0.20",
     "python-dotenv==1.1.1",
+    "boto3>=1.35.0",
 ]

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ if [ ! -d "backend" ]; then
 fi
 
 echo "Starting Course Materials RAG System..."
-echo "Make sure you have set your ANTHROPIC_API_KEY in .env"
+echo "Make sure you have configured your AI provider in .env (ANTHROPIC_API_KEY or AI_PROVIDER=bedrock)"
 
-# Change to backend directory and start the server
-cd backend && uv run uvicorn app:app --reload --port 8000
+# Start the server from project root
+uv run uvicorn backend.app:app --reload --port 8000

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -108,6 +108,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/40/f2/71b4ed65ce38982ecdda0ff20c3ad1b15e71949c78b2c053df53629ce940/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505", size = 363128, upload-time = "2025-02-28T01:23:50.399Z" },
     { url = "https://files.pythonhosted.org/packages/11/99/12f6a58eca6dea4be992d6c681b7ec9410a1d9f5cf368c61437e31daa879/bcrypt-4.3.0-cp39-abi3-win32.whl", hash = "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a", size = 160598, upload-time = "2025-02-28T01:23:51.775Z" },
     { url = "https://files.pythonhosted.org/packages/a9/cf/45fb5261ece3e6b9817d3d82b2f343a505fd58674a92577923bc500bd1aa/bcrypt-4.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b", size = 152799, upload-time = "2025-02-28T01:23:53.139Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.40.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/dd/485d58afea6bf58638c0dbd7716d1505a80735cb94e9faececcccb1d1b31/boto3-1.40.4.tar.gz", hash = "sha256:6eceffe4ae67c2cb077574289c0efe3ba60e8446646893a974fc3c2fa1130e7c", size = 112020, upload-time = "2025-08-06T19:35:03.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/57/3f57dbab55802e4e8fef1cd45b5d30411de44f0f9cf9c78594c75a2bea46/boto3-1.40.4-py3-none-any.whl", hash = "sha256:95cdc86454e9ff43e0693c5d807a54ce6813b6711d3543a0052ead5216b93367", size = 140060, upload-time = "2025-08-06T19:35:01.093Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.40.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/65/4f95659b9b2778d347bd9aacf7e1007dc2d89819ad9985da44a0d2ac1c63/botocore-1.40.4.tar.gz", hash = "sha256:f1dacde69ec8b08f39bcdb62247bab4554938b5d7f8805ade78447da55c9df36", size = 14313555, upload-time = "2025-08-06T19:34:52.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/4a/1389763674d2cea707726a4d0f4021a600fecb5f9272ee61c8446f412be2/botocore-1.40.4-py3-none-any.whl", hash = "sha256:4e131c52731e10a6af998c2ac3bfbda12e6ecef0e3633268c7752d0502c74197", size = 13973723, upload-time = "2025-08-06T19:34:46.174Z" },
 ]
 
 [[package]]
@@ -516,6 +544,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/b3/2bd02071c5a2430d0b70403a34411fc519c2f227da7b03da9ba6a956f931/jiter-0.10.0-cp314-cp314-win32.whl", hash = "sha256:ac509f7eccca54b2a29daeb516fb95b6f0bd0d0d8084efaf8ed5dfc7b9f0b357", size = 210127, upload-time = "2025-05-18T19:04:38.837Z" },
     { url = "https://files.pythonhosted.org/packages/03/0c/5fe86614ea050c3ecd728ab4035534387cd41e7c1855ef6c031f1ca93e3f/jiter-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5ed975b83a2b8639356151cef5c0d597c68376fc4922b45d0eb384ac058cfa00", size = 318527, upload-time = "2025-05-18T19:04:40.612Z" },
     { url = "https://files.pythonhosted.org/packages/b3/4a/4175a563579e884192ba6e81725fc0448b042024419be8d83aa8a80a3f44/jiter-0.10.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3aa96f2abba33dc77f79b4cf791840230375f9534e5fac927ccceb58c5e604a5", size = 354213, upload-time = "2025-05-18T19:04:41.894Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
 ]
 
 [[package]]
@@ -1406,6 +1443,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/05/d52bf1e65044b4e5e27d4e63e8d1579dbdec54fce685908ae09bc3720030/s3transfer-0.13.1.tar.gz", hash = "sha256:c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf", size = 150589, upload-time = "2025-07-18T19:22:42.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/4f/d073e09df851cfa251ef7840007d04db3293a0482ce607d2b993926089be/s3transfer-0.13.1-py3-none-any.whl", hash = "sha256:a981aa7429be23fe6dfc13e80e4020057cbab622b08c0315288758d67cabc724", size = 85308, upload-time = "2025-07-18T19:22:40.947Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1553,6 +1602,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "boto3" },
     { name = "chromadb" },
     { name = "fastapi" },
     { name = "python-dotenv" },
@@ -1564,6 +1614,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = "==0.58.2" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "chromadb", specifier = "==1.0.15" },
     { name = "fastapi", specifier = "==0.116.1" },
     { name = "python-dotenv", specifier = "==1.1.1" },


### PR DESCRIPTION
## Summary

- Add comprehensive AWS Bedrock support alongside existing Anthropic API
- Support for latest Claude models (Sonnet 4, Opus 4.1, Haiku 3.5) via inference profiles
- Frictionless setup requiring only `AI_PROVIDER=bedrock` environment variable
- Abstract AI generator interface with factory pattern for provider selection

## Key Features

- **Dual Provider Support**: Switch between direct Anthropic API and AWS Bedrock with single env var
- **Latest Models**: Claude Sonnet 4 and Opus 4.1 via proper Bedrock inference profiles  
- **Smart Authentication**: Auto-detects AWS credentials from profiles or environment variables
- **Sensible Defaults**: Uses `us-east-1` region and Sonnet 4 model out of the box
- **Backward Compatible**: Existing Anthropic API usage continues to work unchanged

## Implementation Details

- Created abstract `BaseAIGenerator` class with `AnthropicAIGenerator` and `BedrockAIGenerator` implementations
- Added `create_ai_generator()` factory function for automatic provider selection
- Enhanced configuration with Bedrock-specific settings and model mappings
- Fixed all import paths to support running from project root directory
- Updated documentation with comprehensive setup instructions

## Test Plan

- ✅ Tested Anthropic API provider (existing functionality)
- ✅ Tested Bedrock provider with Sonnet 4 using inference profiles  
- ✅ Tested Bedrock provider with Opus 4.1
- ✅ Verified full RAG pipeline works end-to-end with both providers
- ✅ Tested web interface and API endpoints with Bedrock backend
- ✅ Confirmed tool-based search and session management work correctly

## Configuration Examples

**Minimal Bedrock setup:**
```bash
AI_PROVIDER=bedrock
# AWS credentials auto-detected from your environment
```

**Advanced configuration:**
```bash
AI_PROVIDER=bedrock
AWS_REGION=us-east-1
AWS_PROFILE=my-profile
BEDROCK_MODEL=opus-4.1
```

Ready for production use with either provider!